### PR TITLE
Make installation simpler -- just "vagrant up"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 Phabricator development box using Vagrant
 
-## Bootstrap ##
+## Quickstart ##
 
 ```bash
-$ vagrant box add squeeze64 http://dl.dropbox.com/u/937870/VMs/squeeze64.box
-$ ln -s $(pwd)/puppet.conf ~/.puppet/puppet.conf
-$ ./bootstrap.sh
+$ git clone https://github.com/xiaogaozi/vagrant-phabricator.git
+$ cd vagrant-phabricator
 $ vagrant up
 ```
+
+Phabricator is now running at http://192.168.33.10/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,11 +7,11 @@ Vagrant.configure("2") do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "squeeze64"
+  config.vm.box = "debian-607-x64-vbox4210"
 
   # The url from where the 'config.vm.box' box will be fetched if it
   # doesn't already exist on the user's system.
-  # config.vm.box_url = "http://domain.com/path/to/above.box"
+  config.vm.box_url = "http://puppet-vagrant-boxes.puppetlabs.com/debian-607-x64-vbox4210.box"
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,
@@ -33,7 +33,7 @@ Vagrant.configure("2") do |config|
   # argument is a set of non-required options.
   # config.vm.synced_folder "../data", "/vagrant_data"
 
-  config.vm.synced_folder ".", "/vagrant", :nfs => true
+  config.vm.synced_folder ".", "/vagrant"
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.
@@ -46,67 +46,10 @@ Vagrant.configure("2") do |config|
     # Use VBoxManage to customize the VM. For example to change memory:
     vb.customize ["modifyvm", :id, "--memory", "512"]
   end
-  #
-  # View the documentation for the provider you're using for more
-  # information on available options.
 
-  # Enable provisioning with Puppet stand alone.  Puppet manifests
-  # are contained in a directory path relative to this Vagrantfile.
-  # You will need to create the manifests directory and a manifest in
-  # the file base.pp in the manifests_path directory.
-  #
-  # An example Puppet manifest to provision the message of the day:
-  #
-  # # group { "puppet":
-  # #   ensure => "present",
-  # # }
-  # #
-  # # File { owner => 0, group => 0, mode => 0644 }
-  # #
-  # # file { '/etc/motd':
-  # #   content => "Welcome to your Vagrant-built virtual machine!
-  # #               Managed by Puppet.\n"
-  # # }
-  #
+  config.vm.provision "shell", path: "bootstrap.sh"
+
   config.vm.provision :puppet do |puppet|
     puppet.module_path = "modules"
   end
-
-  # Enable provisioning with chef solo, specifying a cookbooks path, roles
-  # path, and data_bags path (all relative to this Vagrantfile), and adding
-  # some recipes and/or roles.
-  #
-  # config.vm.provision :chef_solo do |chef|
-  #   chef.cookbooks_path = "../my-recipes/cookbooks"
-  #   chef.roles_path = "../my-recipes/roles"
-  #   chef.data_bags_path = "../my-recipes/data_bags"
-  #   chef.add_recipe "mysql"
-  #   chef.add_role "web"
-  #
-  #   # You may also specify custom JSON attributes:
-  #   chef.json = { :mysql_password => "foo" }
-  # end
-
-  # Enable provisioning with chef server, specifying the chef server URL,
-  # and the path to the validation key (relative to this Vagrantfile).
-  #
-  # The Opscode Platform uses HTTPS. Substitute your organization for
-  # ORGNAME in the URL and validation key.
-  #
-  # If you have your own Chef Server, use the appropriate URL, which may be
-  # HTTP instead of HTTPS depending on your configuration. Also change the
-  # validation key to validation.pem.
-  #
-  # config.vm.provision :chef_client do |chef|
-  #   chef.chef_server_url = "https://api.opscode.com/organizations/ORGNAME"
-  #   chef.validation_key_path = "ORGNAME-validator.pem"
-  # end
-  #
-  # If you're using the Opscode platform, your validator client is
-  # ORGNAME-validator, replacing ORGNAME with your organization name.
-  #
-  # If you have your own Chef Server, the default validation client name is
-  # chef-validator, unless you changed the configuration.
-  #
-  #   chef.validation_client_name = "ORGNAME-validator"
 end

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -16,5 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-puppet module install puppetlabs-apt
-puppet module install puppetlabs-mysql
+install_module () {
+  if ! puppet module list | grep -q "$1"; then
+    puppet module install "$1"
+  fi
+}
+
+install_module puppetlabs-apt
+install_module puppetlabs-mysql

--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -6,13 +6,13 @@ class { 'apt':
 }
 
 apt::source { 'debian':
-  location    => 'http://mirrors.163.com/debian/',
+  location    => 'http://http.debian.net/debian/',
   repos       => 'main contrib non-free',
   include_src => false
 }
 
 apt::source { 'debian_updates':
-  location    => 'http://mirrors.163.com/debian/',
+  location    => 'http://http.debian.net/debian/',
   release     => "${::lsbdistcodename}-proposed-updates",
   repos       => 'main contrib non-free',
   include_src => false

--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -50,7 +50,7 @@ nginx::server { 'ph.dev':
 include php
 
 class { 'mysql::server':
-  config_hash => { 'root_password' => 'root' }
+  root_password => 'root',
 }
 
 file { '/etc/profile.d/ph.sh':

--- a/modules/nginx/templates/ph.conf.erb
+++ b/modules/nginx/templates/ph.conf.erb
@@ -1,8 +1,8 @@
 server {
   listen      80;
-  server_name <%= servername %>;
+  server_name <%= @servername %>;
 
-  root      <%= root %>;
+  root      <%= @root %>;
   try_files $uri $uri/ /index.php;
 
   location / {

--- a/puppet.conf
+++ b/puppet.conf
@@ -1,2 +1,0 @@
-[main]
-modulepath = ./modules:$confdir/modules


### PR DESCRIPTION
PR includes a couple changes which should make installation simpler and more universally correct. For example:
- don't use a Debian mirror in China
- get a more recent puppet in the VM by using vagrant box from puppetlabs
- configure Vagrant to do the bootstrapping (installing modules, downloading and adding box if necessary)

Though these are steps in the right direction, it still doesn't working. Remaining issues I know about:
- nothing actually installs phabricator. I guess it's intended for someone to put something in `/vagrant/webroot`, but I'm not exactly sure what.
- puppet attempts to install `mysql` before doing an `apt-get update`, so many of the packages are 404. This is probably a matter of adding the right resource dependency somewhere in the manifest, but I didn't dig deeply enough to figure it out.
